### PR TITLE
feat: add user-tunable pace and fatigue settings

### DIFF
--- a/src/components/trailData/PaceSettings/PaceSettings.jsx
+++ b/src/components/trailData/PaceSettings/PaceSettings.jsx
@@ -1,0 +1,126 @@
+import { memo, useCallback, useState } from "react";
+
+import { RotateCcw } from "@styled-icons/feather/RotateCcw";
+import { useShallow } from "zustand/react/shallow";
+
+import {
+  BASE_PACE_STEP_S_PER_KM,
+  K_FATIGUE_STEP,
+  MAX_BASE_PACE_S_PER_KM,
+  MAX_K_FATIGUE,
+  MIN_BASE_PACE_S_PER_KM,
+  MIN_K_FATIGUE,
+} from "../../../constants.js";
+import useStore from "../../../store/store.js";
+
+import style from "./PaceSettings.style.js";
+
+// Format a pace in seconds-per-km as mm:ss/km (e.g. 530 → "8:50/km").
+function formatPace(secondsPerKm) {
+  const total = Math.round(secondsPerKm);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}/km`;
+}
+
+const PaceSettings = memo(function PaceSettings({ className }) {
+  const { basePace, kFatigue, setBasePace, setKFatigue, resetPaceSettings } =
+    useStore(
+      useShallow((state) => ({
+        basePace: state.settings.basePace,
+        kFatigue: state.settings.kFatigue,
+        setBasePace: state.setBasePace,
+        setKFatigue: state.setKFatigue,
+        resetPaceSettings: state.resetPaceSettings,
+      })),
+    );
+
+  // Local drafts give instant slider feedback; the store (which triggers an
+  // expensive GPX re-process) is only updated when the user releases the slider.
+  const [paceDraft, setPaceDraft] = useState(basePace);
+  const [fatigueDraft, setFatigueDraft] = useState(kFatigue);
+
+  // Keep drafts in sync when the store changes externally (e.g. reset,
+  // rehydrate) using the "adjust state during render" pattern.
+  const [prevBasePace, setPrevBasePace] = useState(basePace);
+  if (basePace !== prevBasePace) {
+    setPrevBasePace(basePace);
+    setPaceDraft(basePace);
+  }
+  const [prevKFatigue, setPrevKFatigue] = useState(kFatigue);
+  if (kFatigue !== prevKFatigue) {
+    setPrevKFatigue(kFatigue);
+    setFatigueDraft(kFatigue);
+  }
+
+  const commitPace = useCallback(
+    () => setBasePace(paceDraft),
+    [setBasePace, paceDraft],
+  );
+  const commitFatigue = useCallback(
+    () => setKFatigue(fatigueDraft),
+    [setKFatigue, fatigueDraft],
+  );
+
+  return (
+    <div className={className}>
+      <div className="settings-header">
+        <span className="header-label">Effort model</span>
+        <button
+          type="button"
+          className="reset-btn"
+          onClick={resetPaceSettings}
+          aria-label="Reset effort settings to defaults"
+          title="Reset to defaults"
+        >
+          <RotateCcw size={13} />
+          <span>Reset</span>
+        </button>
+      </div>
+
+      <label className="field" htmlFor="pace-base">
+        <span className="field-label">
+          Base pace
+          <strong>{formatPace(paceDraft)}</strong>
+        </span>
+        <input
+          id="pace-base"
+          type="range"
+          min={MIN_BASE_PACE_S_PER_KM}
+          max={MAX_BASE_PACE_S_PER_KM}
+          step={BASE_PACE_STEP_S_PER_KM}
+          value={paceDraft}
+          onChange={(e) => setPaceDraft(Number(e.target.value))}
+          onPointerUp={commitPace}
+          onKeyUp={commitPace}
+          onBlur={commitPace}
+          aria-valuetext={formatPace(paceDraft)}
+        />
+        <span className="field-hint">Flat-terrain reference pace.</span>
+      </label>
+
+      <label className="field" htmlFor="pace-fatigue">
+        <span className="field-label">
+          Fatigue
+          <strong>{fatigueDraft.toFixed(4)}</strong>
+        </span>
+        <input
+          id="pace-fatigue"
+          type="range"
+          min={MIN_K_FATIGUE}
+          max={MAX_K_FATIGUE}
+          step={K_FATIGUE_STEP}
+          value={fatigueDraft}
+          onChange={(e) => setFatigueDraft(Number(e.target.value))}
+          onPointerUp={commitFatigue}
+          onKeyUp={commitFatigue}
+          onBlur={commitFatigue}
+          aria-valuetext={`Fatigue ${fatigueDraft.toFixed(4)}`}
+        />
+        <span className="field-hint">Higher values slow later sections.</span>
+      </label>
+    </div>
+  );
+});
+
+export default style(PaceSettings);

--- a/src/components/trailData/PaceSettings/PaceSettings.style.js
+++ b/src/components/trailData/PaceSettings/PaceSettings.style.js
@@ -1,0 +1,119 @@
+import { rgba } from "polished";
+import styled from "styled-components";
+
+const text = (props) =>
+  props.theme.colors[props.theme.currentVariant]["--color-text"];
+const background = (props) =>
+  props.theme.colors[props.theme.currentVariant]["--color-background"];
+const primary = (props) =>
+  props.theme.colors[props.theme.currentVariant]["--color-primary"];
+
+const style = (Component) => styled(Component)`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: 0 0.75rem;
+  overflow: hidden;
+
+  .settings-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid ${(props) => rgba(text(props), 0.07)};
+    margin-bottom: 0.75rem;
+    flex-shrink: 0;
+  }
+
+  .header-label {
+    font-family: ${(props) => props.theme.font.family["--font-family-mono"]};
+    font-size: ${(props) => props.theme.font.sizes["--font-size-tiny"]};
+    font-weight: ${(props) => props.theme.font.weights["--font-weight-bold"]};
+    color: ${(props) => rgba(text(props), 0.35)};
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+  }
+
+  .reset-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: ${(props) => rgba(text(props), 0.5)};
+    font-family: ${(props) => props.theme.font.family["--font-family-mono"]};
+    font-size: ${(props) => props.theme.font.sizes["--font-size-tiny"]};
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    transition: color ${(props) => props.theme.transitions["--transition-fast"]};
+
+    &:hover {
+      color: ${(props) => text(props)};
+    }
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-bottom: 1rem;
+  }
+
+  .field-label {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    font-size: ${(props) => props.theme.font.sizes["--font-size-small"]};
+    color: ${(props) => rgba(text(props), 0.85)};
+
+    strong {
+      font-family: ${(props) => props.theme.font.family["--font-family-mono"]};
+      font-variant-numeric: tabular-nums;
+      color: ${(props) => primary(props)};
+    }
+  }
+
+  .field-hint {
+    font-size: ${(props) => props.theme.font.sizes["--font-size-tiny"]};
+    color: ${(props) => rgba(text(props), 0.45)};
+  }
+
+  input[type="range"] {
+    width: 100%;
+    appearance: none;
+    -webkit-appearance: none;
+    height: 4px;
+    border-radius: 999px;
+    background: ${(props) => rgba(text(props), 0.18)};
+    cursor: pointer;
+    outline: none;
+
+    &::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: ${(props) => primary(props)};
+      border: 2px solid ${(props) => background(props)};
+      cursor: pointer;
+    }
+
+    &::-moz-range-thumb {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: ${(props) => primary(props)};
+      border: 2px solid ${(props) => background(props)};
+      cursor: pointer;
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 3px ${(props) => rgba(primary(props), 0.4)};
+    }
+  }
+`;
+
+export default style;

--- a/src/components/trailData/PaceSettings/PaceSettings.test.jsx
+++ b/src/components/trailData/PaceSettings/PaceSettings.test.jsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import useStore from "../../../store/store.js";
+import PaceSettings from "./PaceSettings.jsx";
+
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("../../../store/store.js", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn) => fn,
+}));
+
+vi.mock("./PaceSettings.style.js", () => ({
+  default: (Component) => (props) => <Component {...props} />,
+}));
+
+describe("PaceSettings", () => {
+  let mockStore;
+
+  beforeEach(() => {
+    mockStore = {
+      settings: { basePace: 530, kFatigue: 0.0035 },
+      setBasePace: vi.fn(),
+      setKFatigue: vi.fn(),
+      resetPaceSettings: vi.fn(),
+    };
+    useStore.mockImplementation((selector) => selector(mockStore));
+  });
+
+  it("renders the base pace formatted as mm:ss/km", () => {
+    render(<PaceSettings />);
+    expect(screen.getByText("8:50/km")).toBeInTheDocument();
+  });
+
+  it("renders the fatigue value with 4 decimals", () => {
+    render(<PaceSettings />);
+    expect(screen.getByText("0.0035")).toBeInTheDocument();
+  });
+
+  it("commits the base pace on pointer up", () => {
+    render(<PaceSettings />);
+    const slider = screen.getByLabelText(/Base pace/i, { selector: "input" });
+    fireEvent.change(slider, { target: { value: "400" } });
+    fireEvent.pointerUp(slider);
+    expect(mockStore.setBasePace).toHaveBeenCalledWith(400);
+  });
+
+  it("commits the fatigue value on pointer up", () => {
+    render(<PaceSettings />);
+    const slider = screen.getByLabelText(/Fatigue/i, { selector: "input" });
+    fireEvent.change(slider, { target: { value: "0.01" } });
+    fireEvent.pointerUp(slider);
+    expect(mockStore.setKFatigue).toHaveBeenCalledWith(0.01);
+  });
+
+  it("resets to defaults", () => {
+    render(<PaceSettings />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Reset effort settings to defaults/i,
+      }),
+    );
+    expect(mockStore.resetPaceSettings).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/trailData/TrailData.jsx
+++ b/src/components/trailData/TrailData.jsx
@@ -10,6 +10,7 @@ import { format } from "date-fns";
 import useStore, { useProjectedLocation, useStats } from "../../store/store.js";
 import EffortBreakdown from "./EffortBreakdown/EffortBreakdown.jsx";
 import PaceProfile from "./PaceProfile/PaceProfile.jsx";
+import PaceSettings from "./PaceSettings/PaceSettings.jsx";
 import PeakSummary from "./PeakSummary/PeakSummary.jsx";
 import SectionAnalytics from "./SectionAnalytics/SectionAnalytics.jsx";
 import StageAnalytics from "./StageAnalytics/StageAnalytics.jsx";
@@ -29,6 +30,7 @@ const PANEL_LABELS = [
   "Effort profile",
   "Pace profile",
   "Peak summary",
+  "Effort model",
   "Trail actions",
 ];
 
@@ -255,6 +257,9 @@ const TrailData = memo(function TrailData({ className }) {
         </div>
         <div className="component-children">
           <PeakSummary />
+        </div>
+        <div className="component-children">
+          <PaceSettings />
         </div>
         <div className="component-children">
           <TrailActions />

--- a/src/components/trailData/TrailData.test.jsx
+++ b/src/components/trailData/TrailData.test.jsx
@@ -101,6 +101,11 @@ vi.mock("./PaceProfile/PaceProfile.jsx", () => ({
   default: () => <div data-testid="pace-profile">PaceProfile</div>,
 }));
 
+// Mock PaceSettings component
+vi.mock("./PaceSettings/PaceSettings.jsx", () => ({
+  default: () => <div data-testid="pace-settings">PaceSettings</div>,
+}));
+
 describe("TrailData Component", () => {
   const mockStats = {
     distance: 10000,

--- a/src/constants.js
+++ b/src/constants.js
@@ -34,3 +34,20 @@ export const DIFFICULTY_COLORS = [
   ELEVATION_COLORS.DIFFICULT, // 4 Very Hard
   ELEVATION_COLORS.HARD, // 5 Extreme
 ];
+
+// ── Minetti pace/effort model — user-tunable inputs ───────────────────────────
+// These mirror the defaults in zig/minetti.zig and drive the section/stage
+// estimated-duration computation. They are user-adjustable (sliders) and
+// persisted to localStorage.
+
+// Flat-terrain reference pace (seconds per km). 530 s/km = 8:50/km.
+export const DEFAULT_BASE_PACE_S_PER_KM = 530;
+export const MIN_BASE_PACE_S_PER_KM = 240; // 4:00/km — fast trail runner
+export const MAX_BASE_PACE_S_PER_KM = 900; // 15:00/km — hiking pace
+export const BASE_PACE_STEP_S_PER_KM = 5;
+
+// Fatigue coefficient added per 1 000 m of effort-weighted distance.
+export const DEFAULT_K_FATIGUE = 0.0035;
+export const MIN_K_FATIGUE = 0; // no cumulative fatigue
+export const MAX_K_FATIGUE = 0.02; // strong fatigue (short, hard efforts)
+export const K_FATIGUE_STEP = 0.0005;

--- a/src/gpxWorker.js
+++ b/src/gpxWorker.js
@@ -2,9 +2,10 @@
 // This runs GPS computations off the main thread to prevent UI freezing
 // All Trace objects must be manually cleaned up with .deinit() to prevent memory leaks
 
-import { readGPXComplete } from "../zig/gpx.zig";
+import { readGPXCompleteWithPace } from "../zig/gpx.zig";
 import { generateAudioFrames } from "../zig/soundscape.zig";
 import { __zigar, Trace } from "../zig/trace.zig";
+import { DEFAULT_BASE_PACE_S_PER_KM, DEFAULT_K_FATIGUE } from "./constants.js";
 
 // Initialize Zig/WASM in worker context
 let isInitialized = false;
@@ -107,7 +108,19 @@ self.onmessage = async function (e) {
 
 async function processGPXFile(gpxFileBytes, requestId) {
   markStart("processGPXFile");
-  const gpxData = await readGPXComplete(gpxFileBytes.gpxBytes);
+  const basePace =
+    typeof gpxFileBytes.basePace === "number"
+      ? gpxFileBytes.basePace
+      : DEFAULT_BASE_PACE_S_PER_KM;
+  const kFatigue =
+    typeof gpxFileBytes.kFatigue === "number"
+      ? gpxFileBytes.kFatigue
+      : DEFAULT_K_FATIGUE;
+  const gpxData = await readGPXCompleteWithPace(
+    gpxFileBytes.gpxBytes,
+    basePace,
+    kFatigue,
+  );
 
   // Convert Zigar proxy objects to plain JS before sending
   // Note: Zig string fields ([]const u8) need .string property to convert to JS strings

--- a/src/gpxWorker.test.js
+++ b/src/gpxWorker.test.js
@@ -1,14 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // vi.mock calls are hoisted above all imports by Vitest
-vi.mock("../zig/gpx.zig", () => ({ readGPXComplete: vi.fn() }));
+vi.mock("../zig/gpx.zig", () => ({ readGPXCompleteWithPace: vi.fn() }));
 vi.mock("../zig/trace.zig", () => ({
   __zigar: { init: vi.fn().mockResolvedValue(undefined) },
   Trace: { init: vi.fn() },
 }));
 vi.mock("../zig/soundscape.zig", () => ({ generateAudioFrames: vi.fn() }));
 
-import { readGPXComplete } from "../zig/gpx.zig";
+import { readGPXCompleteWithPace as readGPXComplete } from "../zig/gpx.zig";
 import { generateAudioFrames } from "../zig/soundscape.zig";
 import { Trace } from "../zig/trace.zig";
 

--- a/src/hooks/useGPXWorker.js
+++ b/src/hooks/useGPXWorker.js
@@ -14,6 +14,8 @@ export function useGPXWorker(raceId) {
     setSections,
     setLegs,
     flush,
+    basePace,
+    kFatigue,
   } = useStore(
     useShallow((state) => ({
       initGPXWorker: state.initGPXWorker,
@@ -23,6 +25,8 @@ export function useGPXWorker(raceId) {
       setSections: state.setSections,
       setLegs: state.setLegs,
       flush: state.flush,
+      basePace: state.settings.basePace,
+      kFatigue: state.settings.kFatigue,
     })),
   );
 
@@ -67,7 +71,16 @@ export function useGPXWorker(raceId) {
     });
 
     return () => controller.abort();
-  }, [isWorkerReady, raceId, processGPXFile, setSections, setLegs, flush]);
+  }, [
+    isWorkerReady,
+    raceId,
+    processGPXFile,
+    setSections,
+    setLegs,
+    flush,
+    basePace,
+    kFatigue,
+  ]);
 
   return { isWorkerReady };
 }

--- a/src/hooks/useGPXWorker.test.js
+++ b/src/hooks/useGPXWorker.test.js
@@ -24,6 +24,7 @@ describe("useGPXWorker", () => {
       setSections: vi.fn(),
       setLegs: vi.fn(),
       flush: vi.fn(),
+      settings: { basePace: 530, kFatigue: 0.0035 },
     };
     useStore.mockImplementation((selector) => selector(mockStore));
     vi.stubGlobal("fetch", vi.fn());

--- a/src/store/slices/settings.js
+++ b/src/store/slices/settings.js
@@ -1,0 +1,61 @@
+import {
+  DEFAULT_BASE_PACE_S_PER_KM,
+  DEFAULT_K_FATIGUE,
+  MAX_BASE_PACE_S_PER_KM,
+  MAX_K_FATIGUE,
+  MIN_BASE_PACE_S_PER_KM,
+  MIN_K_FATIGUE,
+} from "../../constants.js";
+
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+// Runner-specific inputs for the Minetti pace/effort model. These drive the
+// section/stage estimated-duration computation in zig/minetti.zig and are
+// persisted to localStorage (see store.js partialize).
+export const createSettingsSlice = (set) => ({
+  settings: {
+    basePace: DEFAULT_BASE_PACE_S_PER_KM,
+    kFatigue: DEFAULT_K_FATIGUE,
+  },
+
+  setBasePace: (value) =>
+    set(
+      (state) => ({
+        settings: {
+          ...state.settings,
+          basePace: clamp(
+            Number(value),
+            MIN_BASE_PACE_S_PER_KM,
+            MAX_BASE_PACE_S_PER_KM,
+          ),
+        },
+      }),
+      undefined,
+      "settings/setBasePace",
+    ),
+
+  setKFatigue: (value) =>
+    set(
+      (state) => ({
+        settings: {
+          ...state.settings,
+          kFatigue: clamp(Number(value), MIN_K_FATIGUE, MAX_K_FATIGUE),
+        },
+      }),
+      undefined,
+      "settings/setKFatigue",
+    ),
+
+  resetPaceSettings: () =>
+    set(
+      (state) => ({
+        settings: {
+          ...state.settings,
+          basePace: DEFAULT_BASE_PACE_S_PER_KM,
+          kFatigue: DEFAULT_K_FATIGUE,
+        },
+      }),
+      undefined,
+      "settings/resetPaceSettings",
+    ),
+});

--- a/src/store/slices/settings.test.js
+++ b/src/store/slices/settings.test.js
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { create } from "zustand";
+
+import {
+  DEFAULT_BASE_PACE_S_PER_KM,
+  DEFAULT_K_FATIGUE,
+  MAX_BASE_PACE_S_PER_KM,
+  MAX_K_FATIGUE,
+  MIN_BASE_PACE_S_PER_KM,
+  MIN_K_FATIGUE,
+} from "../../constants.js";
+import { createSettingsSlice } from "./settings";
+
+describe("settingsSlice", () => {
+  let store;
+  beforeEach(() => {
+    store = create((set, get) => ({
+      ...createSettingsSlice(set, get),
+    }));
+  });
+
+  describe("initial state", () => {
+    it("should default to the Minetti model defaults", () => {
+      expect(store.getState().settings).toEqual({
+        basePace: DEFAULT_BASE_PACE_S_PER_KM,
+        kFatigue: DEFAULT_K_FATIGUE,
+      });
+    });
+  });
+
+  describe("setBasePace", () => {
+    it("should update the base pace", () => {
+      store.getState().setBasePace(400);
+      expect(store.getState().settings.basePace).toBe(400);
+    });
+
+    it("should clamp to the allowed range", () => {
+      store.getState().setBasePace(MAX_BASE_PACE_S_PER_KM + 1000);
+      expect(store.getState().settings.basePace).toBe(MAX_BASE_PACE_S_PER_KM);
+
+      store.getState().setBasePace(MIN_BASE_PACE_S_PER_KM - 1000);
+      expect(store.getState().settings.basePace).toBe(MIN_BASE_PACE_S_PER_KM);
+    });
+
+    it("should not affect kFatigue", () => {
+      store.getState().setBasePace(400);
+      expect(store.getState().settings.kFatigue).toBe(DEFAULT_K_FATIGUE);
+    });
+  });
+
+  describe("setKFatigue", () => {
+    it("should update the fatigue coefficient", () => {
+      store.getState().setKFatigue(0.01);
+      expect(store.getState().settings.kFatigue).toBe(0.01);
+    });
+
+    it("should clamp to the allowed range", () => {
+      store.getState().setKFatigue(MAX_K_FATIGUE + 1);
+      expect(store.getState().settings.kFatigue).toBe(MAX_K_FATIGUE);
+
+      store.getState().setKFatigue(MIN_K_FATIGUE - 1);
+      expect(store.getState().settings.kFatigue).toBe(MIN_K_FATIGUE);
+    });
+  });
+
+  describe("resetPaceSettings", () => {
+    it("should restore the defaults", () => {
+      store.getState().setBasePace(400);
+      store.getState().setKFatigue(0.01);
+      store.getState().resetPaceSettings();
+      expect(store.getState().settings).toEqual({
+        basePace: DEFAULT_BASE_PACE_S_PER_KM,
+        kFatigue: DEFAULT_K_FATIGUE,
+      });
+    });
+  });
+});

--- a/src/store/slices/worker.js
+++ b/src/store/slices/worker.js
@@ -259,9 +259,11 @@ export const createWorkerSlice = (set, get, workerFactory) => {
           throw new Error(ERROR_MESSAGES.NOT_INITIALIZED);
         }
 
+        const { basePace, kFatigue } = get().settings;
+
         const results = await messenger.send(
           "PROCESS_GPX_FILE",
-          { gpxBytes },
+          { gpxBytes, basePace, kFatigue },
           onProgress,
         );
 

--- a/src/store/slices/worker.test.js
+++ b/src/store/slices/worker.test.js
@@ -55,6 +55,10 @@ describe("Worker Slice", () => {
       sections: [],
       stages: [],
       waypoints: [],
+      settings: {
+        basePace: 530,
+        kFatigue: 0.0035,
+      },
       gps: {
         location: { timestamp: 0, coords: [] },
         projectedLocation: { timestamp: 0, coords: [], index: null },

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -7,6 +7,7 @@ import { createGPSSlice } from "./slices/gps";
 import { createGpxSlice } from "./slices/gpx";
 import { createLegsSlice } from "./slices/legs";
 import { createSectionsSlice } from "./slices/sections";
+import { createSettingsSlice } from "./slices/settings";
 import { createStagesSlice } from "./slices/stages";
 import { createStatsSlice } from "./slices/stats";
 import { createWayPointsSlice } from "./slices/wayPoints";
@@ -25,6 +26,7 @@ const useStore = create(
         ...createLegsSlice(...a),
         ...createSectionsSlice(...a),
         ...createStagesSlice(...a),
+        ...createSettingsSlice(...a),
         ...createGPSSlice(...a),
         ...createWeatherSlice(...a),
       })),
@@ -35,6 +37,10 @@ const useStore = create(
           ...persistedState,
           app: { ...currentState.app, ...(persistedState.app ?? {}) },
           gps: { ...currentState.gps, ...(persistedState.gps ?? {}) },
+          settings: {
+            ...currentState.settings,
+            ...(persistedState.settings ?? {}),
+          },
         }),
         partialize: (state) => ({
           app: {
@@ -54,6 +60,10 @@ const useStore = create(
             location: state.gps.location,
             projectedLocation: state.gps.projectedLocation,
             savedLocations: state.gps.savedLocations,
+          },
+          settings: {
+            basePace: state.settings.basePace,
+            kFatigue: state.settings.kFatigue,
           },
         }),
         onRehydrateStorage: () => (state) => {
@@ -89,6 +99,7 @@ export const useAppState = () => useStore((state) => state.app);
 export const useGpxData = () => useStore((state) => state.gpx);
 export const useStats = () => useStore((state) => state.stats);
 export const useWorkerState = () => useStore((state) => state.worker);
+export const useSettings = () => useStore((state) => state.settings);
 
 // Specific selectors for common use cases
 export const useTrackingMode = () =>

--- a/src/store/store.test.js
+++ b/src/store/store.test.js
@@ -149,8 +149,8 @@ describe("store", () => {
       const { partialize } = useStore.persist.getOptions();
       const persisted = partialize(useStore.getState());
 
-      // Only app and gps should be present
-      expect(Object.keys(persisted).sort()).toEqual(["app", "gps"]);
+      // Only app, gps and settings should be present
+      expect(Object.keys(persisted).sort()).toEqual(["app", "gps", "settings"]);
     });
 
     it("partialize app contains exactly the expected fields", () => {
@@ -180,6 +180,15 @@ describe("store", () => {
 
       expect(Object.keys(gps).sort()).toEqual(
         ["location", "projectedLocation", "savedLocations"].sort(),
+      );
+    });
+
+    it("partialize settings contains exactly the expected fields", () => {
+      const { partialize } = useStore.persist.getOptions();
+      const { settings } = partialize(useStore.getState());
+
+      expect(Object.keys(settings).sort()).toEqual(
+        ["basePace", "kFatigue"].sort(),
       );
     });
 

--- a/zig/gpx.zig
+++ b/zig/gpx.zig
@@ -10,6 +10,7 @@ const section_mod = @import("section.zig");
 const SectionStats = section_mod.SectionStats;
 const stage_mod = @import("stage.zig");
 const StageStats = stage_mod.StageStats;
+const minetti = @import("minetti.zig");
 const parseIso8601ToEpoch = @import("time.zig").parseIso8601ToEpoch;
 
 pub fn readTracePoints(allocator: std.mem.Allocator, bytes: []const u8) ![][3]f64 {
@@ -206,7 +207,27 @@ pub fn readMetadata(allocator: std.mem.Allocator, bytes: []const u8) !Metadata {
     return metadata;
 }
 
+/// Parse a complete GPX document using the default base pace and fatigue coefficient
+/// (see zig/minetti.zig). Thin wrapper kept for callers/tests that don't supply
+/// runner-specific values.
 pub fn readGPXComplete(allocator: std.mem.Allocator, bytes: []const u8) !GPXData {
+    return readGPXCompleteWithPace(
+        allocator,
+        bytes,
+        minetti.DEFAULT_BASE_PACE_S_PER_KM,
+        minetti.K_FATIGUE,
+    );
+}
+
+/// Parse a complete GPX document, using a runner-specific flat-terrain base pace
+/// (`base_pace_s_per_km`, seconds per km) and fatigue coefficient (`k_fatigue`,
+/// added per 1 000 m of effort-weighted distance) for section/stage estimates.
+pub fn readGPXCompleteWithPace(
+    allocator: std.mem.Allocator,
+    bytes: []const u8,
+    base_pace_s_per_km: f64,
+    k_fatigue: f64,
+) !GPXData {
     var metadata = try readMetadata(allocator, bytes);
     errdefer metadata.deinit(allocator);
 
@@ -233,11 +254,11 @@ pub fn readGPXComplete(allocator: std.mem.Allocator, bytes: []const u8) !GPXData
     errdefer if (legs) |l| allocator.free(l);
 
     // Sections: computed between consecutive section-boundary waypoints (Start/TimeBarrier/LifeBase/Arrival)
-    const sections: ?[]const SectionStats = try section_mod.computeFromWaypoints(&trace, allocator, waypoints);
+    const sections: ?[]const SectionStats = try section_mod.computeFromWaypointsWithPace(&trace, allocator, waypoints, base_pace_s_per_km, k_fatigue);
     errdefer if (sections) |s| allocator.free(s);
 
     // Stages: computed between consecutive stage-boundary waypoints (Start/LifeBase/Arrival)
-    const stages: ?[]const StageStats = try stage_mod.computeFromWaypoints(&trace, allocator, waypoints);
+    const stages: ?[]const StageStats = try stage_mod.computeFromWaypointsWithPace(&trace, allocator, waypoints, base_pace_s_per_km, k_fatigue);
     errdefer if (stages) |st| allocator.free(st);
 
     return GPXData{
@@ -564,7 +585,6 @@ test "readTracePoints with scientific notation" {
     try testing.expectApproxEqAbs(100.0, points[0][2], 0.01);
 }
 
-
 test "readWaypoints parses waypoints correctly" {
     const allocator = testing.allocator;
     const sample_gpx =
@@ -661,7 +681,6 @@ test "readGPXComplete parses both tracks and waypoints" {
     try testing.expectEqualStrings("Checkpoint 10km", gpx_data.waypoints[0].name);
     try testing.expectEqualStrings("Checkpoint 20km", gpx_data.waypoints[1].name);
 }
-
 
 test "readGPXComplete: legs null when no waypoints" {
     const allocator = testing.allocator;

--- a/zig/section.zig
+++ b/zig/section.zig
@@ -32,9 +32,32 @@ pub const SectionStats = struct {
     maxCompletionTime: ?i64, // seconds allowed (endTime - startTime), null if absent
 };
 
+/// Compute section statistics using the default base pace and fatigue coefficient
+/// (see zig/minetti.zig). Thin wrapper kept for callers/tests that don't supply
+/// runner-specific values.
+pub fn computeFromWaypoints(trace: *const Trace, allocator: std.mem.Allocator, waypoints: []const Waypoint) !?[]SectionStats {
+    return computeFromWaypointsWithPace(
+        trace,
+        allocator,
+        waypoints,
+        minetti.DEFAULT_BASE_PACE_S_PER_KM,
+        minetti.K_FATIGUE,
+    );
+}
+
 /// Compute section statistics between consecutive section-boundary waypoints
 /// (Start/TimeBarrier/LifeBase/Arrival). Returns null when fewer than 2 section boundaries.
-pub fn computeFromWaypoints(trace: *const Trace, allocator: std.mem.Allocator, waypoints: []const Waypoint) !?[]SectionStats {
+///
+/// `base_pace_s_per_km` is the runner's flat-terrain reference pace (seconds per km) and
+/// `k_fatigue` is the fatigue coefficient (added per 1 000 m of effort-weighted distance).
+/// See zig/minetti.zig for the defaults used when no user value is supplied.
+pub fn computeFromWaypointsWithPace(
+    trace: *const Trace,
+    allocator: std.mem.Allocator,
+    waypoints: []const Waypoint,
+    base_pace_s_per_km: f64,
+    k_fatigue: f64,
+) !?[]SectionStats {
     // Collect section-boundary waypoints (those with a non-null wptType)
     var section_wpts = std.ArrayList(Waypoint){};
     defer section_wpts.deinit(allocator);
@@ -112,8 +135,8 @@ pub fn computeFromWaypoints(trace: *const Trace, allocator: std.mem.Allocator, w
             const slope_frac = trace.slopes[j] / 100.0;
             const seg_dist = trace.cumulativeDistances[j + 1] - trace.cumulativeDistances[j];
             const pf = minetti.paceFactor(slope_frac);
-            const fatigue_factor = 1.0 + minetti.K_FATIGUE * (d_eff / 1000.0);
-            total_time += (seg_dist / 1000.0) * minetti.DEFAULT_BASE_PACE_S_PER_KM * pf * fatigue_factor;
+            const fatigue_factor = 1.0 + k_fatigue * (d_eff / 1000.0);
+            total_time += (seg_dist / 1000.0) * base_pace_s_per_km * pf * fatigue_factor;
             total_weighted_dist += seg_dist * pf;
             d_eff += seg_dist * pf;
         }
@@ -205,8 +228,8 @@ test "computeSectionsFromWaypoints: basic two-boundary section" {
     defer trace.deinit(allocator);
 
     const waypoints = [_]Waypoint{
-        .{ .lat = 0.000, .lon = 0.0, .name = "Start",   .wptType = "Start",       .time = null },
-        .{ .lat = 0.003, .lon = 0.0, .name = "TB1",     .wptType = "TimeBarrier", .time = null },
+        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start", .time = null },
+        .{ .lat = 0.003, .lon = 0.0, .name = "TB1", .wptType = "TimeBarrier", .time = null },
     };
 
     const sections = try computeFromWaypoints(&trace, allocator, &waypoints);
@@ -234,11 +257,11 @@ test "computeSectionsFromWaypoints: plain (untyped) waypoints are ignored" {
 
     // 3 section boundaries with plain waypoints interspersed
     const waypoints = [_]Waypoint{
-        .{ .lat = 0.000, .lon = 0.0, .name = "Start",  .wptType = "Start",       .time = null },
-        .{ .lat = 0.001, .lon = 0.0, .name = "Plain1", .wptType = null,           .time = null },
-        .{ .lat = 0.002, .lon = 0.0, .name = "TB1",    .wptType = "TimeBarrier", .time = null },
-        .{ .lat = 0.003, .lon = 0.0, .name = "Plain2", .wptType = null,           .time = null },
-        .{ .lat = 0.005, .lon = 0.0, .name = "End",    .wptType = "Arrival",     .time = null },
+        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start", .time = null },
+        .{ .lat = 0.001, .lon = 0.0, .name = "Plain1", .wptType = null, .time = null },
+        .{ .lat = 0.002, .lon = 0.0, .name = "TB1", .wptType = "TimeBarrier", .time = null },
+        .{ .lat = 0.003, .lon = 0.0, .name = "Plain2", .wptType = null, .time = null },
+        .{ .lat = 0.005, .lon = 0.0, .name = "End", .wptType = "Arrival", .time = null },
     };
 
     const sections = try computeFromWaypoints(&trace, allocator, &waypoints);
@@ -264,11 +287,11 @@ test "computeSectionsFromWaypoints: stageIdx increments at LifeBase boundary" {
     // Stage 0: Start→TB1, TB1→LifeBase  (sections 0 and 1)
     // Stage 1: LifeBase→TB2, TB2→Arrival (sections 2 and 3)
     const waypoints = [_]Waypoint{
-        .{ .lat = 0.000, .lon = 0.0, .name = "Start",   .wptType = "Start",       .time = null },
-        .{ .lat = 0.003, .lon = 0.0, .name = "TB1",     .wptType = "TimeBarrier", .time = null },
-        .{ .lat = 0.006, .lon = 0.0, .name = "LB1",     .wptType = "LifeBase",    .time = null },
-        .{ .lat = 0.009, .lon = 0.0, .name = "TB2",     .wptType = "TimeBarrier", .time = null },
-        .{ .lat = 0.011, .lon = 0.0, .name = "Arrival", .wptType = "Arrival",     .time = null },
+        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start", .time = null },
+        .{ .lat = 0.003, .lon = 0.0, .name = "TB1", .wptType = "TimeBarrier", .time = null },
+        .{ .lat = 0.006, .lon = 0.0, .name = "LB1", .wptType = "LifeBase", .time = null },
+        .{ .lat = 0.009, .lon = 0.0, .name = "TB2", .wptType = "TimeBarrier", .time = null },
+        .{ .lat = 0.011, .lon = 0.0, .name = "Arrival", .wptType = "Arrival", .time = null },
     };
 
     const sections = try computeFromWaypoints(&trace, allocator, &waypoints);
@@ -296,8 +319,8 @@ test "computeSectionsFromWaypoints: maxCompletionTime computed from timestamps" 
     defer trace.deinit(allocator);
 
     const waypoints = [_]Waypoint{
-        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start",       .time = 1_000_000 },
-        .{ .lat = 0.003, .lon = 0.0, .name = "End",   .wptType = "TimeBarrier", .time = 1_007_200 },
+        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start", .time = 1_000_000 },
+        .{ .lat = 0.003, .lon = 0.0, .name = "End", .wptType = "TimeBarrier", .time = 1_007_200 },
     };
 
     const sections = try computeFromWaypoints(&trace, allocator, &waypoints);
@@ -322,8 +345,8 @@ test "computeSectionsFromWaypoints: maxCompletionTime is null without timestamps
     defer trace.deinit(allocator);
 
     const waypoints = [_]Waypoint{
-        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start",   .time = null },
-        .{ .lat = 0.002, .lon = 0.0, .name = "End",   .wptType = "Arrival", .time = null },
+        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start", .time = null },
+        .{ .lat = 0.002, .lon = 0.0, .name = "End", .wptType = "Arrival", .time = null },
     };
 
     const sections = try computeFromWaypoints(&trace, allocator, &waypoints);
@@ -333,4 +356,36 @@ test "computeSectionsFromWaypoints: maxCompletionTime is null without timestamps
     try std.testing.expectEqual(@as(?i64, null), sections.?[0].maxCompletionTime);
     try std.testing.expectEqual(@as(?i64, null), sections.?[0].startTime);
     try std.testing.expectEqual(@as(?i64, null), sections.?[0].endTime);
+}
+
+test "computeFromWaypointsWithPace: slower base pace and higher fatigue increase estimatedDuration" {
+    const allocator = std.testing.allocator;
+    var points = try allocator.alloc([3]f64, 12);
+    defer allocator.free(points);
+    for (0..12) |i| {
+        const t = @as(f64, @floatFromInt(i)) * 0.001;
+        points[i] = [3]f64{ t, 0.0, 100.0 + t * 500.0 };
+    }
+    var trace = try Trace.init(allocator, points);
+    defer trace.deinit(allocator);
+
+    const waypoints = [_]Waypoint{
+        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start", .time = null },
+        .{ .lat = 0.011, .lon = 0.0, .name = "Arrival", .wptType = "Arrival", .time = null },
+    };
+
+    const fast = try computeFromWaypointsWithPace(&trace, allocator, &waypoints, 300.0, 0.0);
+    defer if (fast) |s| allocator.free(s);
+    const slow = try computeFromWaypointsWithPace(&trace, allocator, &waypoints, 600.0, 0.0);
+    defer if (slow) |s| allocator.free(s);
+    const fatigued = try computeFromWaypointsWithPace(&trace, allocator, &waypoints, 600.0, 0.02);
+    defer if (fatigued) |s| allocator.free(s);
+
+    try std.testing.expect(fast != null and slow != null and fatigued != null);
+    // Doubling the base pace roughly doubles the estimate.
+    try std.testing.expect(slow.?[0].estimatedDuration > fast.?[0].estimatedDuration);
+    // Adding fatigue on top of the same base pace makes it longer still.
+    try std.testing.expect(fatigued.?[0].estimatedDuration > slow.?[0].estimatedDuration);
+    // The pace factor (slope-only) is independent of base pace / fatigue.
+    try std.testing.expectApproxEqAbs(fast.?[0].paceFactor, slow.?[0].paceFactor, 1e-9);
 }

--- a/zig/stage.zig
+++ b/zig/stage.zig
@@ -34,9 +34,32 @@ pub const StageStats = struct {
     maxCompletionTime: ?i64, // seconds allowed (endTime - startTime), null if absent
 };
 
+/// Compute stage statistics using the default base pace and fatigue coefficient
+/// (see zig/minetti.zig). Thin wrapper kept for callers/tests that don't supply
+/// runner-specific values.
+pub fn computeFromWaypoints(trace: *const Trace, allocator: std.mem.Allocator, waypoints: []const Waypoint) !?[]StageStats {
+    return computeFromWaypointsWithPace(
+        trace,
+        allocator,
+        waypoints,
+        minetti.DEFAULT_BASE_PACE_S_PER_KM,
+        minetti.K_FATIGUE,
+    );
+}
+
 /// Compute stage statistics between consecutive stage-boundary waypoints (Start/LifeBase/Arrival).
 /// TimeBarrier waypoints are skipped — they only appear in sections, not stages.
-pub fn computeFromWaypoints(trace: *const Trace, allocator: std.mem.Allocator, waypoints: []const Waypoint) !?[]StageStats {
+///
+/// `base_pace_s_per_km` is the runner's flat-terrain reference pace (seconds per km) and
+/// `k_fatigue` is the fatigue coefficient (added per 1 000 m of effort-weighted distance).
+/// See zig/minetti.zig for the defaults used when no user value is supplied.
+pub fn computeFromWaypointsWithPace(
+    trace: *const Trace,
+    allocator: std.mem.Allocator,
+    waypoints: []const Waypoint,
+    base_pace_s_per_km: f64,
+    k_fatigue: f64,
+) !?[]StageStats {
     // Collect stage-boundary waypoints (Start/LifeBase/Arrival)
     var stage_wpts = std.ArrayList(Waypoint){};
     defer stage_wpts.deinit(allocator);
@@ -100,8 +123,8 @@ pub fn computeFromWaypoints(trace: *const Trace, allocator: std.mem.Allocator, w
             const slope_frac = trace.slopes[j] / 100.0;
             const seg_dist = trace.cumulativeDistances[j + 1] - trace.cumulativeDistances[j];
             const pf = minetti.paceFactor(slope_frac);
-            const fatigue_factor = 1.0 + minetti.K_FATIGUE * (d_eff / 1000.0);
-            total_time += (seg_dist / 1000.0) * minetti.DEFAULT_BASE_PACE_S_PER_KM * pf * fatigue_factor;
+            const fatigue_factor = 1.0 + k_fatigue * (d_eff / 1000.0);
+            total_time += (seg_dist / 1000.0) * base_pace_s_per_km * pf * fatigue_factor;
             total_weighted_dist += seg_dist * pf;
             d_eff += seg_dist * pf;
         }
@@ -186,9 +209,9 @@ test "computeStagesFromWaypoints: TimeBarrier waypoints are excluded" {
     // TimeBarrier at 0.002 is a section boundary but NOT a stage boundary — should be skipped.
     // Result: 1 stage (Start→Arrival), not 2.
     const waypoints = [_]Waypoint{
-        .{ .lat = 0.000, .lon = 0.0, .name = "Start",   .wptType = "Start",       .time = null },
-        .{ .lat = 0.002, .lon = 0.0, .name = "TB1",     .wptType = "TimeBarrier", .time = null },
-        .{ .lat = 0.005, .lon = 0.0, .name = "Arrival", .wptType = "Arrival",     .time = null },
+        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start", .time = null },
+        .{ .lat = 0.002, .lon = 0.0, .name = "TB1", .wptType = "TimeBarrier", .time = null },
+        .{ .lat = 0.005, .lon = 0.0, .name = "Arrival", .wptType = "Arrival", .time = null },
     };
 
     const stages = try computeFromWaypoints(&trace, allocator, &waypoints);
@@ -212,9 +235,9 @@ test "computeStagesFromWaypoints: Start-LifeBase-Arrival produces two stages" {
     defer trace.deinit(allocator);
 
     const waypoints = [_]Waypoint{
-        .{ .lat = 0.000, .lon = 0.0, .name = "Start",    .wptType = "Start",    .time = null },
+        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start", .time = null },
         .{ .lat = 0.005, .lon = 0.0, .name = "LifeBase", .wptType = "LifeBase", .time = null },
-        .{ .lat = 0.009, .lon = 0.0, .name = "Arrival",  .wptType = "Arrival",  .time = null },
+        .{ .lat = 0.009, .lon = 0.0, .name = "Arrival", .wptType = "Arrival", .time = null },
     };
 
     const stages = try computeFromWaypoints(&trace, allocator, &waypoints);
@@ -246,8 +269,8 @@ test "stage maxCompletionTime is set from waypoint timestamps" {
     defer trace.deinit(allocator);
 
     const waypoints = [_]Waypoint{
-        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start",   .time = 1_000_000 },
-        .{ .lat = 0.003, .lon = 0.0, .name = "End",   .wptType = "Arrival", .time = 1_003_600 },
+        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start", .time = 1_000_000 },
+        .{ .lat = 0.003, .lon = 0.0, .name = "End", .wptType = "Arrival", .time = 1_003_600 },
     };
 
     const stages = try computeFromWaypoints(&trace, allocator, &waypoints);
@@ -275,8 +298,8 @@ test "stage maxCompletionTime is null when stage waypoints have no timestamps" {
     defer trace.deinit(allocator);
 
     const waypoints = [_]Waypoint{
-        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start",   .time = null },
-        .{ .lat = 0.003, .lon = 0.0, .name = "End",   .wptType = "Arrival", .time = null },
+        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start", .time = null },
+        .{ .lat = 0.003, .lon = 0.0, .name = "End", .wptType = "Arrival", .time = null },
     };
 
     const stages = try computeFromWaypoints(&trace, allocator, &waypoints);
@@ -285,4 +308,33 @@ test "stage maxCompletionTime is null when stage waypoints have no timestamps" {
     try expect(stages != null);
     try expectEqual(@as(usize, 1), stages.?.len);
     try expectEqual(@as(?i64, null), stages.?[0].maxCompletionTime);
+}
+
+test "computeFromWaypointsWithPace: slower base pace and higher fatigue increase estimatedDuration" {
+    const allocator = std.testing.allocator;
+    var points = try allocator.alloc([3]f64, 12);
+    defer allocator.free(points);
+    for (0..12) |i| {
+        const t = @as(f64, @floatFromInt(i)) * 0.001;
+        points[i] = [3]f64{ t, 0.0, 100.0 + t * 500.0 };
+    }
+    var trace = try Trace.init(allocator, points);
+    defer trace.deinit(allocator);
+
+    const waypoints = [_]Waypoint{
+        .{ .lat = 0.000, .lon = 0.0, .name = "Start", .wptType = "Start", .time = null },
+        .{ .lat = 0.011, .lon = 0.0, .name = "Arrival", .wptType = "Arrival", .time = null },
+    };
+
+    const fast = try computeFromWaypointsWithPace(&trace, allocator, &waypoints, 300.0, 0.0);
+    defer if (fast) |st| allocator.free(st);
+    const slow = try computeFromWaypointsWithPace(&trace, allocator, &waypoints, 600.0, 0.0);
+    defer if (slow) |st| allocator.free(st);
+    const fatigued = try computeFromWaypointsWithPace(&trace, allocator, &waypoints, 600.0, 0.02);
+    defer if (fatigued) |st| allocator.free(st);
+
+    try expect(fast != null and slow != null and fatigued != null);
+    try expect(slow.?[0].estimatedDuration > fast.?[0].estimatedDuration);
+    try expect(fatigued.?[0].estimatedDuration > slow.?[0].estimatedDuration);
+    try std.testing.expectApproxEqAbs(fast.?[0].paceFactor, slow.?[0].paceFactor, 1e-9);
 }


### PR DESCRIPTION
Thread base pace and fatigue coefficient through the Zig/WASM, worker, store and UI layers so runners can adjust the Minetti effort model via sliders. Values are clamped, persisted to localStorage, and trigger a GPX re-process on change.